### PR TITLE
Rename limsUuid to aliquotId and update its type to string in the create-aliquot-in-mlwh schema

### DIFF
--- a/create-aliquot.avsc
+++ b/create-aliquot.avsc
@@ -21,14 +21,14 @@
             "doc": "Date (UTC) that the message was created."
         },
         {
-            "name": "id_aliquot_lims",
+            "name": "limsId",
             "type": "string",
             "doc": "The LIMS system that the aliquot was created in"
         },
         {
             "name": "aliquotId",
             "type": "string",
-            "doc": "The ID of the aliquot in the LIMS system"
+            "doc": "The ID of the aliquot that was created in."
         },
         {
             "name": "aliquotType",
@@ -74,10 +74,12 @@
                 "symbols": [
                     "library",
                     "pool",
-                    "run"
+                    "run",
+                    "none"
                 ]
             },
-            "doc": "The type of the entity that the aliquot is used by"
+            "doc": "The type of the entity that the aliquot is used by",
+            "default": "none"
         },
         {
             "name": "usedByBarcode",
@@ -96,6 +98,15 @@
                 "float"
             ],
             "doc": "The concentration of the aliquot (ng/ul)",
+            "default": null
+        },
+        {
+            "name": "insertSize",
+            "type": [
+                "null",
+                "int"
+            ],
+            "doc": "The insert size for the aliquot",
             "default": null
         },
         {

--- a/create-aliquot.avsc
+++ b/create-aliquot.avsc
@@ -27,7 +27,10 @@
         },
         {
             "name": "aliquotId",
-            "type": "string",
+            "type": {
+                "type": "string",
+                "logicalType": "uuid"
+            },
             "doc": "The ID of the aliquot that was created in."
         },
         {

--- a/create-aliquot.avsc
+++ b/create-aliquot.avsc
@@ -26,7 +26,7 @@
             "doc": "The LIMS system that the aliquot was created in"
         },
         {
-            "name": "limsUuid",
+            "name": "aliquotId",
             "type": "string",
             "doc": "The ID of the aliquot in the LIMS system"
         },

--- a/create-aliquot.avsc
+++ b/create-aliquot.avsc
@@ -27,11 +27,8 @@
         },
         {
             "name": "limsUuid",
-            "type": {
-                "type": "string",
-                "logicalType": "uuid"
-            },
-            "doc": "The UUID of the aliquot in the LIMS system"
+            "type": "string",
+            "doc": "The ID of the aliquot in the LIMS system"
         },
         {
             "name": "aliquotType",

--- a/create-aliquot.avsc
+++ b/create-aliquot.avsc
@@ -21,7 +21,7 @@
             "doc": "Date (UTC) that the message was created."
         },
         {
-            "name": "limsId",
+            "name": "id_aliquot_lims",
             "type": "string",
             "doc": "The LIMS system that the aliquot was created in"
         },


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- The attribute `lims_uuid` is misleading as it contains the ID of the aliquot at Traction.
    - Update the type from UUID to String in the schema

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
